### PR TITLE
Add documentation for minor Combine AWS configurable features

### DIFF
--- a/docs/Combine-AWS/start-here/10-advanced-features/additional-configuration-options.md
+++ b/docs/Combine-AWS/start-here/10-advanced-features/additional-configuration-options.md
@@ -1,0 +1,35 @@
+# Additional Configuration Options
+
+## Suppress TAP Dashboard Asset Logging
+
+By default, Combine logs HTTP requests for TAP Dashboard web assets (JavaScript, CSS, images, etc.). This can produce high log volume. You can suppress these requests from the log:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.tap.logging.suppress.assets` | `true` / `false` | When `true`, suppresses log entries for TAP Dashboard asset requests |
+
+## Rewriter and Filter Conditions
+
+Individual API Request/Response Rewriters and Filters can be selectively enabled or disabled based on additional criteria.
+
+### Enable/Disable by Role Name
+
+Rewriters and Filters can be scoped to only apply (or be skipped) when a specific IAM Role Name was used to sign the transaction. Refer to the configuration documentation for a specific rewriter for the exact property name; the pattern is:
+
+```
+combine.endpoints.aws.rewriter.<rewriter-name>.roleArn.enable
+combine.endpoints.aws.rewriter.<rewriter-name>.roleArn.disable
+```
+
+### Enable/Disable by AWS Account Number
+
+Rewriters and Filters can be force-enabled or disabled for requests from a specific AWS Account Number:
+
+```
+combine.endpoints.aws.rewriter.<rewriter-name>.account.enable
+combine.endpoints.aws.rewriter.<rewriter-name>.account.disable
+```
+
+## Setting Configuration Values
+
+All configuration values above are set in the Combine Configuration DynamoDB table (`combine-configuration`). See [Edit Combine Configuration Values](../../../tutorials/operations/how-to-edit-combine-configuration.md) for instructions.

--- a/docs/Combine-AWS/start-here/10-advanced-features/aws-api-logging.md
+++ b/docs/Combine-AWS/start-here/10-advanced-features/aws-api-logging.md
@@ -1,0 +1,49 @@
+# AWS API Request Logging
+
+Combine can log AWS API Requests passing through it to a DynamoDB table for auditing and analysis.
+
+## Enabling AWS API Logging
+
+AWS API Logging is disabled by default. It can be enabled or disabled from the TAP Dashboard under **Settings > AWS API Logging**, or by setting the following configuration value:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.api.logging.enable` | `true` / `false` | Enable or disable AWS API Request Logging |
+
+## Filtering by AWS Account
+
+By default, all accounts are logged. You can restrict logging to specific AWS Account IDs:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.api.logging.accounts` | Comma-separated account IDs | Only log requests from these accounts |
+| `combine.endpoints.aws.api.logging.accounts.except` | Comma-separated account IDs | Log all accounts except these |
+
+## Filtering by AWS Service
+
+You can restrict logging to specific AWS Services:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.api.logging.services` | Comma-separated service names | Only log requests for these services |
+| `combine.endpoints.aws.api.logging.services.except` | Comma-separated service names | Log all services except these |
+
+## Ignoring Failed Requests
+
+By default, failed AWS API Requests are included in the log. You can configure Combine to omit failed requests:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.api.logging.ignore.response.status.failed` | `true` / `false` | When `true`, failed API requests are not written to the log |
+
+## Log Storage
+
+Logs are written to a DynamoDB table. The table name can be configured:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.api.logging.table` | DynamoDB table name | The table where API log entries are stored |
+
+## Setting Configuration Values
+
+All configuration values above are set in the Combine Configuration DynamoDB table (`combine-configuration`). See [Edit Combine Configuration Values](../../../tutorials/operations/how-to-edit-combine-configuration.md) for instructions on how to update configuration values.

--- a/docs/Combine-AWS/start-here/10-advanced-features/kubernetes-proxy-access-control.md
+++ b/docs/Combine-AWS/start-here/10-advanced-features/kubernetes-proxy-access-control.md
@@ -1,0 +1,35 @@
+# Kubernetes Proxy Access Control
+
+The Combine Kubernetes Proxy can be configured to allow or deny requests based on the source IP address (CIDR block) or the IAM Role ARN used to sign the request.
+
+## Enabling and Disabling the Kubernetes Proxy
+
+The Kubernetes Proxy can be toggled globally:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.kubernetes.proxy` | `true` / `false` | Enable or disable the Combine Kubernetes Proxy globally |
+
+## Filtering by Source IP (CIDR Block)
+
+You can restrict Kubernetes Proxy access to specific CIDR blocks of source IP addresses:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.kubernetes.proxy.ip` | Comma-separated CIDR blocks | Allow Kubernetes Proxy requests only from these source IP ranges |
+| `combine.endpoints.kubernetes.proxy.ip.except` | Comma-separated CIDR blocks | Allow requests from all source IPs except these CIDR ranges |
+
+## Filtering by Role ARN
+
+You can restrict Kubernetes Proxy access to requests signed by specific IAM Role ARNs:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.kubernetes.proxy.roleArn` | Comma-separated Role ARNs | Allow Kubernetes Proxy requests only from these Role ARNs |
+| `combine.endpoints.kubernetes.proxy.roleArn.except` | Comma-separated Role ARNs | Allow requests from all Role ARNs except these |
+
+Multiple allow conditions (IP and Role ARN) can be combined — a request must satisfy all configured conditions to be proxied.
+
+## Setting Configuration Values
+
+All configuration values above are set in the Combine Configuration DynamoDB table (`combine-configuration`). See [Edit Combine Configuration Values](../../../tutorials/operations/how-to-edit-combine-configuration.md) for instructions.

--- a/docs/Combine-AWS/start-here/10-advanced-features/pki-certificate-parameters.md
+++ b/docs/Combine-AWS/start-here/10-advanced-features/pki-certificate-parameters.md
@@ -1,0 +1,40 @@
+# PKI Certificate Parameters
+
+Combine's PKI certificate settings — such as key size, signing algorithm, and certificate encryption — can be customized through Combine Configuration.
+
+These settings can also be configured from the TAP Dashboard under **Settings > PKI Certificates**.
+
+## Certificate Key and Signing Options
+
+| Parameter Name | Example Value | Description |
+|---|---|---|
+| `combine.tap.certificates.key.size` | `2048`, `4096` | RSA key size in bits for generated certificates |
+| `combine.tap.certificates.hash.algorithm` | `SHA256withRSA` | Signing algorithm used for certificate generation |
+
+## Certificate Encryption
+
+User and server certificate private keys can optionally be encrypted at rest:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.tap.certificates.user.key.encrypted` | `true` / `false` | When `true`, encrypts the private key in user certificates |
+| `combine.tap.certificates.server.key.encrypted` | `true` / `false` | When `true`, encrypts the private key in server certificates |
+
+## Custom DNS Names
+
+Additional DNS Subject Alternative Names (SANs) can be added to TAP and Endpoints certificates to support custom DNS zones or external access:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.tap.certificates.dns.tap.custom` | Comma-separated DNS names | Additional DNS SANs added to the TAP server certificate |
+| `combine.tap.certificates.dns.endpoints.custom` | Comma-separated DNS names | Additional DNS SANs added to the Endpoints server certificate |
+| `combine.tap.certificates.dns.tap.directAccess` | Comma-separated DNS names | Direct-access DNS names for the TAP server |
+| `combine.tap.certificates.dns.endpoints.directAccess` | Comma-separated DNS names | Direct-access DNS names for Endpoints servers |
+| `combine.tap.certificates.dns.tap.directAccess.external` | Comma-separated DNS names | External DNS names for TAP direct access |
+| `combine.tap.certificates.dns.endpoints.directAccess.external` | Comma-separated DNS names | External DNS names for Endpoints direct access |
+
+## Setting Configuration Values
+
+All configuration values above are set in the Combine Configuration DynamoDB table (`combine-configuration`). See [Edit Combine Configuration Values](../../../tutorials/operations/how-to-edit-combine-configuration.md) for instructions.
+
+_NOTE: Changes to certificate parameters require a certificate rebuild to take effect. Contact your Combine Support Team for assistance with certificate rotation._

--- a/docs/Combine-AWS/start-here/10-advanced-features/resource-role-masquerade.md
+++ b/docs/Combine-AWS/start-here/10-advanced-features/resource-role-masquerade.md
@@ -1,0 +1,22 @@
+# Resource Role Masquerade
+
+Resource Role Masquerade allows Combine to assume the IAM role attached to an AWS resource (such as an EC2 instance profile or Lambda execution role) when evaluating access for that resource. This enables more accurate emulation of resource-based access patterns.
+
+## Enabling Resource Role Masquerade
+
+Resource Role Masquerade is disabled by default. It can be enabled or disabled from the TAP Dashboard under **Settings**, or by setting the following configuration value:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.authorization.resourceRole.masquerade` | `true` / `false` | Enable or disable Resource Role Masquerade |
+
+## Additional Options
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.authorization.resourceRole.masquerade.cacheTime` | Duration in milliseconds | How long to cache the assumed resource role. Defaults to 60000 (60 seconds) |
+| `combine.endpoints.aws.authorization.resourceRole.masquerade.log.violation` | `true` / `false` | When `true`, logs cases where resource role assumption is attempted but fails |
+
+## Setting Configuration Values
+
+All configuration values above are set in the Combine Configuration DynamoDB table (`combine-configuration`). See [Edit Combine Configuration Values](../../../tutorials/operations/how-to-edit-combine-configuration.md) for instructions.

--- a/docs/Combine-AWS/start-here/10-advanced-features/user-agent-injection.md
+++ b/docs/Combine-AWS/start-here/10-advanced-features/user-agent-injection.md
@@ -1,0 +1,15 @@
+# User-Agent Header Injection
+
+Combine can inject a `SequoiaCombine/<version>` string into the `User-Agent` header of each AWS API Call it handles. This allows downstream AWS services or logging systems to identify traffic that has passed through Combine.
+
+## Enabling User-Agent Injection
+
+User-Agent injection is disabled by default. Enable it by setting the following configuration value:
+
+| Parameter Name | Value | Description |
+|---|---|---|
+| `combine.endpoints.aws.rewriter.request.inject.userAgent.combineAgent.enable` | `true` / `false` | When `true`, appends `SequoiaCombine/<version>` to the `User-Agent` header on every outbound AWS API call |
+
+## Setting Configuration Values
+
+This configuration value is set in the Combine Configuration DynamoDB table (`combine-configuration`). See [Edit Combine Configuration Values](../../../tutorials/operations/how-to-edit-combine-configuration.md) for instructions.


### PR DESCRIPTION
## Summary

Documents configurable features from recent Combine AWS release notes (3.12–3.14) that were previously undocumented. All new pages are added under `docs/Combine-AWS/start-here/10-advanced-features/`.

- **`aws-api-logging.md`** — Enable/disable AWS API Request Logging; filter by account or service; ignore failed requests; configure the log DynamoDB table
- **`user-agent-injection.md`** — Inject `SequoiaCombine/<version>` into the `User-Agent` header of outbound AWS API calls
- **`kubernetes-proxy-access-control.md`** — Restrict the Kubernetes Proxy by source IP CIDR block or IAM Role ARN
- **`resource-role-masquerade.md`** — Enable Combine to assume the IAM role attached to an AWS resource for more accurate emulation
- **`pki-certificate-parameters.md`** — Configure certificate key size, signing algorithm, encryption, and custom DNS SANs
- **`additional-configuration-options.md`** — Suppress TAP Dashboard asset logging; enable/disable rewriters by Role Name or AWS Account Number

All features were sourced from the `release-notes.md` improvements sections and cross-referenced against backend config keys in the combine-aws codebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_013gtdH5GSdntqZ3y8uJfYHp)_